### PR TITLE
Teta 578

### DIFF
--- a/lib/testrail-add-milestone/index.js
+++ b/lib/testrail-add-milestone/index.js
@@ -15,12 +15,24 @@ const checkForMilestone = async (api, projectId, milestoneName) => {
   }
 }
 
+function getCurrentDateTime () {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  const dateTimeString = `${year}-${month}-${day} ${hours}:${minutes}`
+  return dateTimeString
+}
+
 const run = async () => {
   try {
     const username = core.getInput('username')
     const password = core.getInput('api-key')
     const projectId = core.getInput('project-id')
     const milestoneName = core.getInput('milestone-name')
+    const dateTime = getCurrentDateTime()
 
     const api = new TestRail({
       host: 'https://15gifts.testrail.net',
@@ -34,7 +46,7 @@ const run = async () => {
     if (!milestoneId) {
       const milestoneResponse = await api.addMilestone(projectId, {
         name: milestoneName,
-        description: `Release ${milestoneName}`,
+        description: dateTime,
       })
       milestoneId = milestoneResponse.id
     }

--- a/lib/testrail-close-passed-runs/action.yml
+++ b/lib/testrail-close-passed-runs/action.yml
@@ -10,6 +10,9 @@ inputs:
   api-key:
     description: 'Testrail Api Key'
     required: true
+  close-all:
+    description: 'Close all runs, not just the ones that are passed'
+    required: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/lib/testrail-close-passed-runs/action.yml
+++ b/lib/testrail-close-passed-runs/action.yml
@@ -10,6 +10,9 @@ inputs:
   api-key:
     description: 'Testrail Api Key'
     required: true
+  milestone-name:
+    description: 'The milestone to close runs for'
+    required: true
   close-all:
     description: 'Close all runs, not just the ones that are passed'
     required: false

--- a/lib/testrail-close-passed-runs/index.js
+++ b/lib/testrail-close-passed-runs/index.js
@@ -6,6 +6,7 @@ const run = async () => {
     const username = core.getInput('username')
     const password = core.getInput('api-key')
     const projectId = core.getInput('project-id')
+    const closeAll = core.getInput('close-all')
 
     const api = new TestRail({
       host: 'https://15gifts.testrail.net',
@@ -15,9 +16,13 @@ const run = async () => {
 
     const openRuns = await api.getRuns(projectId, { is_completed: 0 })
 
-    const filteredRuns = openRuns.filter(run =>
-      run.blocked_count + run.untested_count + run.retest_count + run.failed_count === 0
-    )
+    let filteredRuns = openRuns
+
+    if (!closeAll || closeAll.toLowerCase() === 'false') {
+      filteredRuns = openRuns.filter(run =>
+        run.blocked_count + run.untested_count + run.retest_count + run.failed_count === 0
+      )
+    }
 
     for (let i = 0; i < filteredRuns.length; i++) {
       await api.closeRun(filteredRuns[i].id)

--- a/lib/testrail-close-passed-runs/index.js
+++ b/lib/testrail-close-passed-runs/index.js
@@ -7,6 +7,7 @@ const run = async () => {
     const password = core.getInput('api-key')
     const projectId = core.getInput('project-id')
     const closeAll = core.getInput('close-all')
+    const milestoneName = core.getInput('milestone-name')
 
     const api = new TestRail({
       host: 'https://15gifts.testrail.net',
@@ -16,10 +17,14 @@ const run = async () => {
 
     const openRuns = await api.getRuns(projectId, { is_completed: 0 })
 
-    let filteredRuns = openRuns
+    const milestoneFilteredRuns = openRuns.filter(run =>
+      run.name.includes(milestoneName)
+    )
+
+    let filteredRuns = milestoneFilteredRuns
 
     if (!closeAll || closeAll.toLowerCase() === 'false') {
-      filteredRuns = openRuns.filter(run =>
+      filteredRuns = milestoneFilteredRuns.filter(run =>
         run.blocked_count + run.untested_count + run.retest_count + run.failed_count === 0
       )
     }


### PR DESCRIPTION
add close-all options to close-passed-runs as well as some better matching for specific milestones rather than just closing everything. 

adding timestamp to milestone description, feels like it'll be useful