### PR TITLE
TD-339: setup-git exec fix

### DIFF
--- a/lib/setup-git/index.js
+++ b/lib/setup-git/index.js
@@ -1,15 +1,19 @@
 const core = require('@actions/core')
-const { exec } = require('child_process') // Lets us run commands from inside an action
+const exec = require('@actions/exec')
 
 const name = core.getInput('name')
 const email = core.getInput('email')
 
-try {
-  const setEmail = `git config --global user.email "${email}"`
-  const setName = `git config --global user.name "${name}"`
-  exec(setEmail)
-  exec(setName)
+const run = async () => {
+  try {
+    const setEmail = `git config --global user.email "${email}"`
+    const setName = `git config --global user.name "${name}"`
+    await exec.exec(setEmail)
+    await exec.exec(setName)
+  }
+  catch (error) {
+    core.setFailed(error.message)
+  }
 }
-catch (error) {
-  core.setFailed(error.message)
-}
+
+run()


### PR DESCRIPTION
`setup-git` calls `exec` which is an async function, without waiting for its result.  This can cause the command to fail.

Modify it to wait for the result.

I've tested this on a test repo and it seems to work OK.